### PR TITLE
Update reselect version to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug": "^3.1.0",
     "esdoc": "^1.0.4",
     "json-pointer": "^0.6.0",
-    "reselect": "^3.0.1",
+    "reselect": "^4.0.0",
     "source-map-support": "^0.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR just updates the `reselect` version to 4.0.0.  I tested it with `truffle-debugger` and encountered no problems.