### PR TITLE
Fix root selector override for plain functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,13 +135,16 @@ export function createSelectorTree (root) {
  */
 function _createNode(node, resolve, pointer = "") {
   //based on type of node, operate differently
-  if (node instanceof Leaf) {
-    // base case - leaf nodes just need context resolution for relative deps
+  if (node instanceof Function) {
+    // plain functions are converted to contextualized Leaf nodes
+    return createLeaf([state => state], node).contextualize(resolve, pointer);
+
+  } else if (node instanceof Leaf) {
+    // explicit leaf nodes just need context resolution for relative deps
     return node.contextualize(resolve, pointer);
 
-  } else if (node instanceof Object && !(node instanceof Function)) {
-    // node is an object, recurse necessary
-
+  } else if (node instanceof Object) {
+    // otherwise, node is an object, so recurse
     const recurse =
       (key, child) => _createNode(child, resolve, `${pointer}/${key}`);
 
@@ -156,7 +159,10 @@ function _createNode(node, resolve, pointer = "") {
     return createNestedSelector(selectors, rootSelector);
 
   } else {
-    // default, just return
-    return node;
+    // other types are not allowed
+    throw new Error(
+      `Invalid node in selector tree at ${pointer}. ` +
+      `Must be function, leaf, or object. Received: ${node}`
+    );
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-runtime": "^6.26.0",
+    "chai": "^4.2.0",
     "express": "^4.16.2",
     "mocha": "^5.0.1",
     "mocha-webpack": "^1.1.0",

--- a/test/selectors.js
+++ b/test/selectors.js
@@ -1,0 +1,81 @@
+import { createSelectorTree, createLeaf } from "../lib";
+import { expect } from "chai";
+
+describe("createSelectorTree", () => {
+  const select = createSelectorTree({
+    shop: {
+      _: createLeaf(
+        ['./info'], ({ name }) => ({ name })
+      ),
+
+      info: ({ shop: { name } }) => ({ name }),
+
+      taxPercent: state => state.shop.taxPercent
+    },
+    cart: {
+      items: state => state.cart.items,
+
+      subtotal: createLeaf(
+        ['./items'],
+
+        (items) => items.reduce((acc, item) => acc + item.value, 0)
+      ),
+
+      tax: createLeaf(
+        ['/shop/taxPercent', './subtotal'],
+
+        (taxPercent, subtotal) => subtotal * (taxPercent / 100)
+      ),
+
+      total: createLeaf(
+        ['./subtotal', './tax'], (subtotal, tax) => subtotal + tax
+      )
+    },
+    buyer: {
+      _: ({ buyer: { name } }) => ({ name })
+    }
+  });
+
+
+  let state = {
+    shop: {
+      name: "Fruit Stand",
+      taxPercent: 8,
+    },
+    cart: {
+      items: [
+        { name: 'apple', value: 1.20 },
+        { name: 'orange', value: 0.95 },
+      ]
+    },
+    buyer: {
+      name: "Abernacky Fidelius"
+    }
+  }
+
+  let expectedCart = {
+    items: [...state.cart.items],
+    subtotal: 2.15,
+    tax: 0.172,
+    total: 2.322
+  };
+
+  it("selects leaf nodes correctly", () => {
+    expect(select.cart.subtotal(state)).to.equal(expectedCart.subtotal);
+    expect(select.cart.tax(state)).to.equal(expectedCart.tax);
+    expect(select.cart.total(state)).to.equal(expectedCart.total);
+  });
+
+  it("selects aggregate nodes correctly", () => {
+    expect(select.cart(state)).to.deep.equal(expectedCart);
+  });
+
+  it("selects root (_) leaf nodes correctly", () => {
+    expect(select.shop(state)).to.deep.equal({ name: state.shop.name });
+  });
+
+  it("selects root (_) function nodes correctly", () => {
+    expect(select.buyer(state)).to.deep.equal({ name: state.buyer.name });
+  });
+
+});


### PR DESCRIPTION
Previously, accessing plain function `./_` selectors as `.` would result in exceptions/undefined results.

- Ensure all plain function nodes are converted to Leaf nodes and contextualized for consistency
- Add some tests following README examples