### PR TITLE
Throw informative errors when selector undefined

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,6 +77,11 @@ class Leaf {
             debug("args: %o", args);
             let selector = resolve(abspath);
             debug("resolved selector: %o", selector);
+            if(!selector) {
+              throw new Error(
+                `Error: Cannot resolve dep ${dep} on ${pointer}`
+              );
+            }
             let result = selector.apply(selector, args);
             debug("result: %o", result);
             return result;


### PR DESCRIPTION
Debugging `reselect-tree` errors is a huge pain, largely because it reports such uninformative error messages.  Meanwhile turning on debug printouts tells you too much information, and not at a time when that information is relevant.

This PR seeks to address one of the most common cases of this: Failure to correctly resolve a selector.  Now, before calling `selector.apply`, if `selector` is undefined, an error will be thrown that actually contains useful information, namely, `pointer` and `dep`, so that you can figure out quickly what went wrong.

Importantly, this means you get information about what you entered wrong -- `pointer` and `dep` -- at the time that the error occurs, rather than at the time that the two are resolved into `abspath`.

Hopefully this will make debugging reselect-tree errors less of a pain.