### PR TITLE
Dependency update: Update json-pointer version to 0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "esdoc": "^1.0.4",
-    "json-pointer": "^0.6.0",
+    "json-pointer": "^0.6.1",
     "reselect": "^4.0.0",
     "source-map-support": "^0.5.3"
   },


### PR DESCRIPTION
Updates the version of json-pointer in reselect-tree to one that dependabot won't complain about.