### PR TITLE
Remove babel; remove source-map-support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,6 @@
 const debugModule = require( "debug");
 const debug = debugModule("reselect-tree");
 
-require("source-map-support/register");
-
 const { createSelector, createStructuredSelector } = require("reselect");
 const jsonpointer = require("json-pointer");
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,10 @@
-import debugModule from "debug";
+const debugModule = require( "debug");
 const debug = debugModule("reselect-tree");
 
-import "source-map-support/register";
+require("source-map-support/register");
 
-import { createSelector, createStructuredSelector } from "reselect";
-import jsonpointer from "json-pointer";
+const { createSelector, createStructuredSelector } = require("reselect");
+const jsonpointer = require("json-pointer");
 
 /**
  * Create a single memoized selector for a collection of named sub-selectors.

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "dependencies": {
     "debug": "^3.1.0",
     "json-pointer": "^0.6.1",
-    "reselect": "^4.0.0",
-    "source-map-support": "^0.5.3"
+    "reselect": "^4.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -34,12 +34,6 @@
     "source-map-support": "^0.5.3"
   },
   "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-loader": "^7.1.3",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-runtime": "^6.26.0",
     "chai": "^4.2.0",
     "express": "^4.16.2",
     "mocha": "^5.0.1",

--- a/webpack/webpack.config-common.js
+++ b/webpack/webpack.config-common.js
@@ -10,17 +10,6 @@ module.exports = {
   module: {
     rules: [{
       test: /\.js$/,
-      loader: "babel-loader",
-      query: {
-        presets: [
-          ['babel-preset-env', {
-            "targets": {
-              "node": "6.9.1"
-            }
-          }]
-        ],
-        plugins: ['transform-object-rest-spread', 'transform-runtime'],
-      },
       include: [
         path.resolve(__dirname, "..", 'lib')
       ],

--- a/webpack/webpack.config-test.js
+++ b/webpack/webpack.config-test.js
@@ -8,11 +8,6 @@ module.exports = merge(commonConfig, {
   module: {
     rules: [{
       test: /\.js$/,
-      loader: "babel-loader",
-      query: {
-        presets: ['babel-preset-env'],
-        plugins: ['transform-object-rest-spread', 'transform-runtime'],
-      },
       include: [
         path.resolve(__dirname, "..", 'lib'),
         path.resolve(__dirname, "..", 'test')


### PR DESCRIPTION
Removes Babel.  This necessitates changing the `import`s to `require`s.  (It doesn't necessitate getting rid of object spreads, because there are none and also who cares about compatibility with Node 6. :P )  Also removes `source-map-support`.  That's really it.  Hopefully this fixes the problems and addresses #12.